### PR TITLE
62 improve and define incremental method of versioning and changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,15 +6,16 @@ Please include a summary of the change and which issue is fixed. Please also inc
 
 Please add linking to issue fixes. Follow the [recommendations](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
 
-Fixes # (issue)
+Fixes #(issue)
 
 ## Type of change
 
-Please delete options that are not relevant.
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation
+- [ ] Configure
+- [ ] Build
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
 
 # How Has This Been Tested?
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,13 +1,14 @@
 changelog:
   categories:
-    - title: Breaking Changes 🛠
+    - title: 'Breaking Changes :fire:'
       labels:
-        - Semver-Major
-        - breaking-change
-    - title: Exciting New Features 🎉
+        - BREAKING CHANGE
+    - title: 'New Features :confetti_ball:'
       labels:
-        - Semver-Minor
-        - enhancement
+        - feature
+    - title: 'Fixes :bug:'
+      labels:
+        - fix
     - title: Other Changes
       labels:
         - "*"

--- a/.github/workflows/labels-test.yml
+++ b/.github/workflows/labels-test.yml
@@ -1,0 +1,57 @@
+name: Labels Test
+
+on:
+  pull_request:
+    branches: [main]
+    types:
+      [opened, reopened, synchronize, labeled, unlabeled]
+
+jobs:
+  labels-test:
+    name: Assign and test labels from conventional-commits
+    if: github.event.pull_request.merged == false
+    runs-on: ubuntu-latest
+    outputs:
+      labels-assigned: ${{ steps.action-assign-labels.outputs.labels-assigned }}
+      labels-removed: ${{ steps.action-assign-labels.outputs.labels-removed }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Assign labels
+        id: action-assign-labels
+        uses: mauroalderete/action-assign-labels@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          conventional-commits: |
+            conventional-commits:
+              - type: 'fix'
+                nouns: ['FIX', 'Fix', 'fix', 'FIXED', 'Fixed', 'fixed']
+                labels: ['fix']
+              - type: 'feature'
+                nouns: ['FEATURE', 'Feature', 'feature', 'FEAT', 'Feat', 'feat']
+                labels: ['feature']
+              - type: 'breaking_change'
+                nouns: ['BREAKING CHANGE', 'BREAKING', 'MAJOR']
+                labels: ['BREAKING CHANGE']
+              - type: 'documentation'
+                nouns: ['doc','docu','document','documentation']
+                labels: ['documentation','fix']
+              - type: 'build'
+                nouns: ['build','rebuild']
+                labels: ['build','fix']
+              - type: 'config'
+                nouns: ['config', 'conf', 'cofiguration', 'configure']
+                labels: ['config','fix']
+
+      - name: Verify labels
+        id: action-verify-labels
+        uses: mauroalderete/action-verify-labels@v1
+        with:
+          none: question, wontfix, invalid
+          some: fix, feature, BREAKING CHANGE
+          request-review: true
+          request-review-header: '**:bookmark: verify-labels-action**'
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,55 +1,73 @@
 name: Versioning
 
 on:
-  pull_request:
-    branches: [ "main" ]
+  push:
+    branches:
+      - "main"
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   versioning:
-    name: Versioning analysis
+    name: Versioning
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.semver.outputs.next }}
     steps:
-      - name: Set up semver tool
-        run: sudo wget -O /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver && semver --version
-
-      - name: Get last tag
-        run: lasttag=$(git describe --tags --abbrev=0)
-
-      - name: Validating tag
-        run: 
-      - uses: actions/checkout@v3
+      - name: Set up repository
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: Setup Go Environment
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
+          ref: ${{ github.event.push.head.ref }}
       
-      - name: Run unit test with coverage report
-        run: go test -v ./... -coverprofile=coverage.out -covermode=count
+      - name: Get next version
+        id: semver
+        uses: ietf-tools/semver-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: main
+          majorList: BREAKING CHANGE, BREAKING, MAJOR
+          minorList: FEATURE, Feature, feature, FEAT, Feat, feat
+          patchList: FIX, Fix, fix, FIXED, Fixed, fixed, config, conf, cofiguration, configure, build, rebuild, doc, docu, document, documentation
+          patchAll: false
+      
+      - name: Push tags
+        id: push-tags
+        run: |
+          #!/bin/sh
+          # Get minor tag
+          minor=$(echo ${{ steps.semver.outputs.next }} | sed 's/.[0-9]\{1,\}$//')
+          # Get major tag
+          major=$(echo ${{ steps.semver.outputs.next }} | sed 's/.[0-9]\{1,\}.[0-9]\{1,\}$//')
+          # Set new tags and force update
+          git tag ${{ steps.semver.outputs.next }}
+          git tag --force $minor
+          git tag --force $major
+          # Push new tag forcing the update of the minor and major tag
+          git push --tag --force
 
-      - name: Save coverage file
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage-file
-          path: ./coverage.out
-  
-  codecov:
-    name: Upload coverage report
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download coverage file
-        uses: actions/download-artifact@v3
-        with:
-          name: coverage-file
+      - name: Create Release from PR
+        id: create-release-from-pr
+        if: github.event.head_commit.committer.username == 'web-flow'
+        run: |
+          #!/bin/sh
+          # The last commit was committed by GitHub.
+          # We assume that the push event come of the a potential pull-request.
+          gh release create ${{ steps.semver.outputs.next }} \
+          --title 'Release ${{ steps.semver.outputs.next }}' \
+          --notes "Changelog Contents :sunglasses:" \
+          --generate-notes \
 
-      - name: Uploading coverage file to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          name: codecov-umbrella
-          file: coverage.out
-          fail_ci_if_error: true
-          flags: unittests
-          verbose: true
+      - name: Create Release from Commits
+        id: create-release-from-commits
+        if: github.event.head_commit.committer.username != 'web-flow'
+        run: |
+          #!/bin/sh
+          
+          echo "::warning ::There were no pull requests associated with the commits included in this release. Automatically-generated notes were not generated."
+          # The last commit was not committed by GitHub.
+          # We assume that the push event come directly.
+          gh release create ${{ steps.semver.outputs.next }} \
+          --title 'Release ${{ steps.semver.outputs.next }}' \
+          --notes "Changelog Contents :sunglasses:" \
+          --generate-notes \

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,55 @@
+name: Versioning
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  versioning:
+    name: Versioning analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up semver tool
+        run: sudo wget -O /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver && semver --version
+
+      - name: Get last tag
+        run: lasttag=$(git describe --tags --abbrev=0)
+
+      - name: Validating tag
+        run: 
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go Environment
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      
+      - name: Run unit test with coverage report
+        run: go test -v ./... -coverprofile=coverage.out -covermode=count
+
+      - name: Save coverage file
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-file
+          path: ./coverage.out
+  
+  codecov:
+    name: Upload coverage report
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download coverage file
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage-file
+
+      - name: Uploading coverage file to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          name: codecov-umbrella
+          file: coverage.out
+          fail_ci_if_error: true
+          flags: unittests
+          verbose: true


### PR DESCRIPTION
# Description

Implement a new versioning scheme and label handle.

For each PR labels-test is triggered. It parses the commits involucrated and searches the conventional-commits prefix associated. With data assign the correspondent labels defined in the workflow configuration. A second step guarantee that the PR contains the minimal labels assigned to the versioning workflow can work.

The versioning workflow parses the commits to search for the correct bump version and bump it creating the new full, minor and major tags.

I adjust the pr template and release to work coordinately with the new workflow.

This strategy depended on:

- [mauroalderete/action-assign-labels@v1](https://github.com/mauroalderete/action-assign-labels)
- [mauroalderete/action-verify-labels@v1](https://github.com/mauroalderete/action-verify-labels)
- [ietf-tools/semver-action@v1](https://github.com/ietf-tools/semver-action)

> After many probes I detect a potential issue in ietf-tools/semver-action@v1... when a commit contains a prefix with spaces this is not detected even if it is defined like indicates in the doc. For example, a commit as "BREAKING CHANGE: fufufu" is not parsed successfully. **I recommend push commits using only the BREAKING prefix for the moment**
# Fixes

Fixes #62 

## Type of change

Configuration