### PR TITLE
59 fix misspell reported by goreportcardcom

### DIFF
--- a/block/gcodeblock/gcodeblock.go
+++ b/block/gcodeblock/gcodeblock.go
@@ -3,7 +3,7 @@
 // This package define GcodeBlock struct as a implemention of block.Blocker interface.
 //
 // Furemore, it defines two package functions that allows create new instances of GcodeBlock.
-// These fucntions can be used to a any instances that implement block.BlockerFactory
+// These functions can be used to a any instances that implement block.BlockerFactory
 package gcodeblock
 
 import (
@@ -155,7 +155,7 @@ func (b *GcodeBlock) Comment() string {
 //
 // %p: series of parameters gcode of the command gcode
 //
-// %k: checksum gcode of the usefull part of the block
+// %k: checksum gcode of the useful part of the block
 //
 // %m: comments of the block
 //
@@ -238,7 +238,7 @@ func New(command gcode.Gcoder, options ...block.BlockConstructorConfigurationCal
 		}
 	}
 
-	// if is necesary, can validate that gcodeBlock is in valid state
+	// if is necessary, can validate that gcodeBlock is in valid state
 	if gcodeBlock.checksum != nil {
 		if ok, err := gcodeBlock.VerifyChecksum(); !ok || err != nil {
 			return gcodeBlock, fmt.Errorf("gcode block %s is invalid, checksum result is %v, error: %w ", gcodeBlock, ok, err)
@@ -339,7 +339,7 @@ func Parse(source string, options ...block.BlockParserConfigurationCallbackable)
 
 	// apply gcodes index getting, using parseQuotesSimplify, on parse
 	// search characters remainders
-	// if there are some characters remaind then is error
+	// if there are some characters remained then is error
 	parseCheckEmpty := parse
 	for _, loc := range gcodesMatchIndex {
 		for i := loc[0]; i < loc[1]; i++ {

--- a/block/gcodeblock/gcodeblock_config.go
+++ b/block/gcodeblock/gcodeblock_config.go
@@ -107,7 +107,7 @@ func (bc *blockConfigurator) SetHash(hash hash.Hash) error {
 }
 
 // SetComment store the block comments. It accept an empty string.
-// If this method isn't called when a new block is created, by default is an emtpy string.
+// If this method isn't called when a new block is created, by default is an empty string.
 func (bc *blockConfigurator) SetComment(comment string) error {
 
 	bc.configurationCallbacks = append(bc.configurationCallbacks, func(gb *GcodeBlock) error {

--- a/block/gcodeblock/gcodeblock_test.go
+++ b/block/gcodeblock/gcodeblock_test.go
@@ -622,7 +622,7 @@ func TestGcodeblogk_Parameters(t *testing.T) {
 			}
 
 			if len(b.Parameters()) != len(tc.parameters) {
-				t.Errorf("got parameters size %d, want paramters size %d", len(b.Parameters()), len(tc.parameters))
+				t.Errorf("got parameters size %d, want parameters size %d", len(b.Parameters()), len(tc.parameters))
 				return
 			}
 

--- a/gcode/addressablegcode/addressable_gcode.go
+++ b/gcode/addressablegcode/addressable_gcode.go
@@ -1,7 +1,7 @@
 // addressablegcode package implements gcode.AddressableGcoder interface to model a gcode with an address element.
 //
 // Define a Gcode struct that implement gcode.AddressableGcoder interface.
-// This struct contain a word field to store the word value and an address field to store the addres value.
+// This struct contain a word field to store the word value and an address field to store the address value.
 //
 // Like AddressableGcoder interface, this Gcode struct use generics with the restrictions defined by AddressType.
 //

--- a/gcode/gcode.go
+++ b/gcode/gcode.go
@@ -39,7 +39,7 @@
 // An address struct that implement AddressableGcoder is bound with a series of methods that allow you to operate with the value of the address.
 //
 // Foremor, gcode package includes GcoderFactory.
-// It is a interace that contains some methods that return a new Gcoder instance or a new AddressableGcoder instance.
+// It is a interacted that contains some methods that return a new Gcoder instance or a new AddressableGcoder instance.
 //
 // gcode package provides two packages that implement all interfaces ready to use.
 package gcode
@@ -75,10 +75,10 @@ type AddressableGcoder[T AddressType] interface {
 	// Gcoder (via the embedded gcode.Gcoder interface) allow converts AddressableGcoder in a Gcoder element.
 	Gcoder
 
-	// Address return addres value of the data type T.
+	// Address return address value of the data type T.
 	Address() T
 
-	// SetAddress stores addres value of the data type T.
+	// SetAddress stores address value of the data type T.
 	// Return an error if the format the value is not valid.
 	SetAddress(value T) error
 }


### PR DESCRIPTION
# Description

I correct some spelling errors indicated in [goreportcard](https://goreportcard.com/report/github.com/mauroalderete/gcode-core#misspell)

# Fixes

Fixes #59 

# How Has This Been Tested?

Passed
