### PR TITLE
remove type of change section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,15 +8,6 @@ Please add linking to issue fixes. Follow the [recommendations](https://docs.git
 
 Fixes #(issue)
 
-## Type of change
-
-- [ ] Documentation
-- [ ] Configure
-- [ ] Build
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Breaking change
-
 # How Has This Been Tested?
 
 Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


### PR DESCRIPTION
# Description

Removed the Change Type section in pull request templates. This is redundant when having automated labeling.

# Fixes

No issue loaded.

# How Has This Been Tested?

No need test
