### PR TITLE
69 when i use blocktoline with float32 gcode address the format showed is missing

### DIFF
--- a/gcode/addressablegcode/addressable_gcode.go
+++ b/gcode/addressablegcode/addressable_gcode.go
@@ -11,7 +11,6 @@ package addressablegcode
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/mauroalderete/gcode-core/gcode"
@@ -79,15 +78,33 @@ func (g *Gcode[T]) SetAddress(address T) error {
 // String return gcode formatted
 func (g *Gcode[T]) String() string {
 
-	if float32Value, ok := any(g.address).(float32); ok {
-		sv := strconv.FormatFloat(float64(float32Value), 'f', -1, 32)
-		if !strings.Contains(sv, ".") {
-			sv += ".0"
+	var address string
+
+	switch value := any(g.address).(type) {
+	case float32:
+		{
+			switch value {
+			case 0:
+				{
+					address = "0.0"
+				}
+			case float32(int(value)):
+				{
+					address = fmt.Sprintf("%.1f", value)
+				}
+			default:
+				{
+					address = strings.TrimRight(fmt.Sprintf("%.3f", value), "0")
+				}
+			}
 		}
-		return fmt.Sprintf("%s%s", string(g.word), sv)
+	default:
+		{
+			address = fmt.Sprintf("%v", g.address)
+		}
 	}
 
-	return fmt.Sprintf("%s%v", string(g.word), g.address)
+	return fmt.Sprintf("%s%s", string(g.word), address)
 }
 
 // Word return a copy of the word struct in the gcode

--- a/gcode/addressablegcode/addressable_gcode_test.go
+++ b/gcode/addressablegcode/addressable_gcode_test.go
@@ -300,4 +300,49 @@ func TestAddressableGcodeWord(t *testing.T) {
 	})
 }
 
+func TestAddressableGcodeString(t *testing.T) {
+	t.Run("float32", func(t *testing.T) {
+
+		var a float32 = 1.2
+		var b float32 = 0.5
+
+		cases := map[string]struct {
+			address float32
+			output  string
+		}{
+			"0": {1, "1.0"},
+			"a": {0, "0.0"},
+			"b": {1.1, "1.1"},
+			"c": {2.2, "2.2"},
+			"d": {float32(1.2), "1.2"},
+			"e": {float32(0.5), "0.5"},
+			"f": {1.2 - 0.5, "0.7"},
+			"g": {float32(1.2) - 0.5, "0.7"},
+			"h": {1.2 - float32(0.5), "0.7"},
+			"i": {float32(1.2) - float32(0.5), "0.7"},
+			"j": {float32(float32(1.2) - float32(0.5)), "0.7"},
+			"k": {a - b, "0.7"},
+			"l": {a / b, "2.4"},
+			"m": {a * b, "0.6"},
+			"n": {a * 0.5, "0.6"},
+			"o": {b / 0.5, "1.0"},
+		}
+
+		for name, tc := range cases {
+			t.Run(name, func(t *testing.T) {
+				gc, err := New('G', tc.address)
+				if err != nil {
+					t.Errorf("failed prepare mock")
+					return
+				}
+
+				if gc.String() != fmt.Sprintf("G%s", tc.output) {
+					t.Errorf("failed print, expected %s, got %s", fmt.Sprintf("G%s", tc.output), gc.String())
+					return
+				}
+			})
+		}
+	})
+}
+
 //#endregion


### PR DESCRIPTION
# Description

Floats numbers in Golang are binary floating-point numbers. It means that his value is an approximation. For more details view the answer in [here](https://stackoverflow.com/questions/46374304/dealing-with-floating-point-number-precision-in-go-arithmetic) and this [document](https://docs.oracle.com/cd/E19957-01/800-7895/800-7895.pdf).

Seems when we print a float32 using the verb f without any another attribute, the output extend the representation value to cover the minimal decimals needed to show the exact value stored.

But, when this float is put through a conversion to a float superior (like a float64), his representation is finally an approximation, because there is not exist information enough to complete this representation. Decimals are missing.

When printing the new result float, the same algorithm extends the print to include the new decimals inserted during of casting.

For this reason, we observe what is described in issue #69  

I change the method String to GcodeAddressable struct to enlarge the particular cases to process and I reduce the decimal exposes to three.

# Fixes

Fixes #69

# How Has This Been Tested?

Add a new test with many cases to represent a float32 value, with or not casting previously.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
